### PR TITLE
Contrôle d'accès compatible Apache 2.2 et 2.4

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,12 @@
 <Files config.ini>
-Order allow,deny
-Deny from all
+    # Apache 2.4
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Order Allow,Deny
+        Deny from all
+    </IfModule>
 </Files>


### PR DESCRIPTION
Les directives Allow, Deny, et Order sont obsolètes et bien souvent désactivées sous Apache 2.4.
Elles sont remplacées par Require.
https://httpd.apache.org/docs/2.4/fr/howto/access.html

Ce pull permet la compatibilité 2.2 et 2.4